### PR TITLE
Improve quiz UI

### DIFF
--- a/Website/vallit-quiz/index.html
+++ b/Website/vallit-quiz/index.html
@@ -8,13 +8,13 @@
 </head>
 <body>
   <header class="topbar">
-    <div class="left">
-    </div>
+    <div class="left"></div>
     <div class="right">
+      <a href="admin.html" id="adminLink" title="Admin Panel" target="_blank">⚙️</a>
       <label class="lang">
-        <select id="langSelect">
-          <option value="en" selected>English</option>
-          <option value="de">Deutsch</option>
+        <select id="langSelect" aria-label="Language">
+          <option value="en" selected>EN</option>
+          <option value="de">DE</option>
         </select>
       </label>
       <label class="switch" aria-label="Night‑Mode">
@@ -39,10 +39,6 @@
     <button id="submitBtn"></button>
     <p id="thanks" hidden>Thanks for helping Vallit decide! 👋</p>
 
-    <!-- quick link to results page -->
-    <p style="margin-top:1.5rem;font-size:.8rem;text-align:right;">
-      <a href="admin.html" target="_blank">Admin Panel</a>
-    </p>
   </main>
 
   <script src="quiz.js"></script>

--- a/Website/vallit-quiz/quiz.js
+++ b/Website/vallit-quiz/quiz.js
@@ -16,7 +16,6 @@ const TEXT = {
       "How exciting would a video be where someone types text using only their thoughts?",
       "Would you click a video that shows how new anti-cheat systems ban cheaters before their first shot?"
     ],
-    tiebreak: "If you could watch only one of these videos right now, which one would you pick?",
     submit: "Submit answers",
     thanks: "Thanks! We'll let you know when the winner is online.",
     extra: {
@@ -54,7 +53,6 @@ const TEXT = {
       "Wie spannend wäre ein Video, in dem jemand nur mit Gedanken Text schreibt?",
       "Würdest du ein Video anklicken, das zeigt, wie neue Anti-Cheats Cheater vor dem ersten Schuss bannen?"
     ],
-    tiebreak: "Wenn du nur eines dieser Videos sofort schauen könntest – welches wählst du?",
     submit: "Antworten absenden",
     thanks: "🎉 Danke! Wir melden uns, wenn das Sieger-Thema online geht.",
     extra: {
@@ -106,6 +104,8 @@ submit.onclick = e => {
   // UI feedback
   form.hidden = true;
   submit.hidden = true;
+  document.getElementById("pageTitle").hidden = true;
+  document.getElementById("intro").hidden = true;
   thanks.hidden = false;
   console.log("Saved Vallit response:", formData);
 };
@@ -123,8 +123,7 @@ function renderForm(lang) {
   const extra2 = t.extra2;
   const TOTAL_FIELDS = t.concepts.length
                      + (extra ? 3 : 0)
-                     + (extra2 ? 4 : 0)
-                     + 1; // ratings + selects + tie‑breaker
+                     + (extra2 ? 4 : 0);
   updateProgress();
 
   /* --- concept cards --- */
@@ -223,18 +222,6 @@ function renderForm(lang) {
     form.appendChild(wrapper);
   }
 
-  // Tie-breaker
-  const tie = document.createElement("fieldset");
-  const leg = document.createElement("legend"); leg.textContent = t.tiebreak; tie.appendChild(leg);
-  order.forEach(i=>{
-    const r = document.createElement("div"); r.className="row";
-    const radio = document.createElement("input");
-    radio.type="radio"; radio.name="favorite"; radio.value=`c${i}`; radio.required=true;
-    radio.addEventListener("change", updateProgress);
-    const label = document.createElement("span"); label.textContent = t.concepts[i].slice(0,60)+"…";
-    r.append(radio,label); tie.appendChild(r);
-  });
-  form.appendChild(tie);
 
   submit.textContent = t.submit;
   submit.disabled = true;

--- a/Website/vallit-quiz/styles.css
+++ b/Website/vallit-quiz/styles.css
@@ -6,6 +6,7 @@
   --text: #111;
   --border: #dcdfe2;
   --accent: #0a84ff; /* calmer blue */
+  --topbar-h: 56px;
 }
 body.dark {
   --bg: #0f1113;
@@ -48,8 +49,8 @@ legend      { font-weight: 600; margin-bottom: .6rem; }
   transform: translateY(-6px);
   box-shadow: 0 10px 24px rgba(0,0,0,.08);
 }
-.conceptText { font-size: .95rem; line-height: 1.4; }
-.ratingRow   { margin-top: .6rem; display: flex; gap: .5rem; }
+.conceptText { font-size: .95rem; line-height: 1.4; margin-bottom: .6rem; }
+.ratingRow   { display: grid; grid-template-columns: repeat(5,1fr); gap: .5rem; }
 .ratingRow input[type=radio]::before {
   content: attr(value);
   position: absolute;
@@ -81,11 +82,13 @@ legend      { font-weight: 600; margin-bottom: .6rem; }
 }
 
 .ratingLabelRow {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(5,1fr);
   gap: .5rem;
   font-size: .75rem;
-  margin-top: .2rem;
+  margin-top: .3rem;
   color: var(--text);
+  text-align: center;
 }
 
 .toggle {
@@ -127,6 +130,11 @@ select {
   color: var(--text);
   font-size: .9rem;
 }
+#langSelect {
+  padding: .3rem .8rem;
+  font-size: .85rem;
+  border-radius: 20px;
+}
 select:focus { outline: none; border-color: var(--accent); }
 
 textarea {
@@ -158,13 +166,19 @@ button:hover { transform: translateY(-2px); opacity: .95; }
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: .8rem 0;
+  margin-top: 20px;
+  height: var(--topbar-h);
   padding-inline: 2vw;
 }
 .topbar .right {
   display: flex;
   align-items: center;
-  gap: 2.5rem;
+  gap: 1.2rem;
+}
+.topbar a#adminLink {
+  text-decoration: none;
+  font-size: 1.2rem;
+  color: var(--text);
 }
 
 #progressBar {


### PR DESCRIPTION
## Summary
- refine header with admin link and cleaner language toggle
- hide intro and header when survey is submitted
- remove tie-breaker question handling
- align rating scales with CSS grid and style tweaks
- adjust progress bar placement

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6855e99ca6148332830d362b1dba193d