### PR TITLE
Create channel site and improve admin link

### DIFF
--- a/Website/vallit-quiz/admin.html
+++ b/Website/vallit-quiz/admin.html
@@ -24,7 +24,7 @@
 </head>
 <body>
   <div id="loginBox">
-    <p>Passwort? Freunde‑Zugang</p>
+    <p>Passwort? Mitarbeiter-Zugang</p>
     <input type="password" id="pw" placeholder="Passwort" />
     <button id="go">Los</button>
   </div>

--- a/Website/vallit-quiz/articles.html
+++ b/Website/vallit-quiz/articles.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Vallit – Home</title>
+  <title>Vallit – Artikel</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -38,16 +38,8 @@
   </header>
 
   <main class="content">
-    <section class="hero">
-      <h1>Willkommen bei Vallit</h1>
-      <p>Hier findest du alle Infos zu unserem YouTube-Kanal, unsere neuesten Videos und spannende Artikel zu Technik-Themen.</p>
-    </section>
-    <section>
-      <h2>Aktuelles Video</h2>
-      <div class="video-wrap">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </section>
+    <h1>Artikel</h1>
+    <p>In Zukunft findest du hier spannende Beiträge und Quellen rund um unsere Videos.</p>
   </main>
 
   <footer class="site-footer">

--- a/Website/vallit-quiz/impressum.html
+++ b/Website/vallit-quiz/impressum.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Vallit – Home</title>
+  <title>Impressum</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -38,16 +38,8 @@
   </header>
 
   <main class="content">
-    <section class="hero">
-      <h1>Willkommen bei Vallit</h1>
-      <p>Hier findest du alle Infos zu unserem YouTube-Kanal, unsere neuesten Videos und spannende Artikel zu Technik-Themen.</p>
-    </section>
-    <section>
-      <h2>Aktuelles Video</h2>
-      <div class="video-wrap">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </section>
+    <h1>Impressum</h1>
+    <p>Diese Seite dient ausschließlich zu Demonstrationszwecken. Bitte füge hier deine vollständigen Impressumsangaben ein.</p>
   </main>
 
   <footer class="site-footer">

--- a/Website/vallit-quiz/quiz.html
+++ b/Website/vallit-quiz/quiz.html
@@ -1,21 +1,18 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Vallit – Home</title>
+  <title>Vallit – Themen‑Voting</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="topbar">
-    <nav class="mainnav">
-      <a href="index.html" class="nav-logo">Vallit</a>
-      <a href="videos.html">Videos</a>
-      <a href="team.html">Team</a>
-      <a href="articles.html">Artikel</a>
-      <a href="quiz.html">Voting</a>
-    </nav>
     <div class="right">
+      <div id="langToggle" class="segmented">
+        <button data-lang="en" class="active">EN</button>
+        <button data-lang="de">DE</button>
+      </div>
       <div id="darkToggle" class="segmented" aria-label="Night mode">
         <button data-mode="light" class="sun active">
           <svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -29,7 +26,7 @@
           </svg>
         </button>
       </div>
-      <a href="admin.html" id="adminLink" class="icon-btn" title="Mitarbeiter Zugang" target="_blank" aria-label="Mitarbeiter Zugang">
+      <a href="admin.html" id="adminLink" class="icon-btn" title="Mitarbeiter Zugang" aria-label="Mitarbeiter Zugang" target="_blank">
         <svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m6-4a4 4 0 11-8 0 4 4 0 018 0zm6 4a4 4 0 10-8 0 4 4 0 008 0z"/>
         </svg>
@@ -37,23 +34,23 @@
     </div>
   </header>
 
-  <main class="content">
-    <section class="hero">
-      <h1>Willkommen bei Vallit</h1>
-      <p>Hier findest du alle Infos zu unserem YouTube-Kanal, unsere neuesten Videos und spannende Artikel zu Technik-Themen.</p>
-    </section>
-    <section>
-      <h2>Aktuelles Video</h2>
-      <div class="video-wrap">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </section>
+  <main>
+    <div id="progressBar">
+      <div id="progressFill"><span id="progressPct">0&nbsp;%</span></div>
+    </div>
+    <div id="progressNote"></div>
+
+    <h1 id="pageTitle"></h1>
+
+    <p id="intro" class="intro"></p>
+
+    <form id="quizForm"></form>
+
+    <button id="submitBtn"></button>
+    <p id="thanks" hidden>Thanks for helping Vallit decide! 👋</p>
+
   </main>
 
-  <footer class="site-footer">
-    <a href="impressum.html">Impressum</a>
-  </footer>
-
-  <script src="site.js"></script>
+  <script src="quiz.js"></script>
 </body>
 </html>

--- a/Website/vallit-quiz/site.js
+++ b/Website/vallit-quiz/site.js
@@ -1,0 +1,21 @@
+const darkToggle = document.getElementById("darkToggle");
+function syncDark(){
+  const on = document.body.classList.contains("dark");
+  localStorage.setItem("vallitDark", on ? "1" : "0");
+  const btnLight = darkToggle.querySelector('[data-mode="light"]');
+  const btnDark  = darkToggle.querySelector('[data-mode="dark"]');
+  btnLight.classList.toggle('active', !on);
+  btnDark.classList.toggle('active', on);
+  darkToggle.style.setProperty('--seg-x', on ? '100%' : '0%');
+}
+if(localStorage.getItem("vallitDark") === "1")
+  document.body.classList.add("dark");
+syncDark();
+darkToggle.addEventListener("click", e => {
+  const btn = e.target.closest('button');
+  if(!btn) return;
+  const mode = btn.dataset.mode;
+  if(mode === 'dark') document.body.classList.add('dark');
+  else document.body.classList.remove('dark');
+  syncDark();
+});

--- a/Website/vallit-quiz/styles.css
+++ b/Website/vallit-quiz/styles.css
@@ -290,3 +290,52 @@ button:hover { transform: translateY(-2px); opacity: .95; }
   margin-bottom: 1.4rem;
   padding-inline: 2vw;
 }
+/* --- site layout additions --- */
+.mainnav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+.nav-logo {
+  font-weight: 600;
+  margin-right: 2rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.mainnav a {
+  text-decoration: none;
+  color: var(--text);
+  font-size: .95rem;
+}
+.mainnav a:hover {
+  text-decoration: underline;
+}
+.content {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 2vw;
+}
+.hero {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+.video-wrap {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+}
+.video-wrap iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.site-footer {
+  margin-top: 3rem;
+  padding: 1rem 2vw;
+  text-align: center;
+  font-size: .85rem;
+}

--- a/Website/vallit-quiz/team.html
+++ b/Website/vallit-quiz/team.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Vallit – Home</title>
+  <title>Vallit – Team</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -38,16 +38,8 @@
   </header>
 
   <main class="content">
-    <section class="hero">
-      <h1>Willkommen bei Vallit</h1>
-      <p>Hier findest du alle Infos zu unserem YouTube-Kanal, unsere neuesten Videos und spannende Artikel zu Technik-Themen.</p>
-    </section>
-    <section>
-      <h2>Aktuelles Video</h2>
-      <div class="video-wrap">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </section>
+    <h1>Unser Team</h1>
+    <p>Hier entsteht eine Übersicht über alle Teammitglieder von Vallit.</p>
   </main>
 
   <footer class="site-footer">

--- a/Website/vallit-quiz/videos.html
+++ b/Website/vallit-quiz/videos.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Vallit – Home</title>
+  <title>Vallit – Videos</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -38,16 +38,13 @@
   </header>
 
   <main class="content">
-    <section class="hero">
-      <h1>Willkommen bei Vallit</h1>
-      <p>Hier findest du alle Infos zu unserem YouTube-Kanal, unsere neuesten Videos und spannende Artikel zu Technik-Themen.</p>
-    </section>
-    <section>
-      <h2>Aktuelles Video</h2>
+    <h1>Unsere Videos</h1>
+    <div class="video-list">
       <div class="video-wrap">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" frameborder="0" allowfullscreen></iframe>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Video 1" frameborder="0" allowfullscreen></iframe>
       </div>
-    </section>
+      <p>Quellen zum Video findest du in der Videobeschreibung auf YouTube.</p>
+    </div>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- rework `index.html` as the homepage with navigation and hero section
- keep the original quiz at `quiz.html`
- add pages for videos, team, articles and impressum
- rename admin panel to *Mitarbeiter Zugang* and switch to a users icon
- extract dark-mode logic into `site.js`
- extend CSS with styles for the new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856bda00cf0833288e7001f46f7e95f